### PR TITLE
chore: add ktlint gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 plugins {
+    alias(libs.plugins.ktlint)
+
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.androidApplication) apply false
@@ -7,4 +9,18 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+}
+
+subprojects {
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    // Enable ktlint's recommended rules
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        // Exclude generated sources from linting
+        filter {
+            exclude("**/build/**")
+        }
+
+        enableExperimentalRules.set(true)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ junit = "4.13.2"
 kotlin = "2.2.10"
 kotlinx-coroutines = "1.10.2"
 firebase-bom = "33.4.0"
+ktlint = "12.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -39,3 +40,4 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
## Summary
- configure ktlint Gradle plugin for code style checks
- enable recommended rules across subprojects

## Testing
- `./gradlew ktlintCheck` *(fails: Plugin [id: 'org.jlleitschuh.gradle.ktlint', version: '12.1.0'] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_e_68bc31196e64833398a48e5619433184